### PR TITLE
Fix 'Storage Asset Preset' link in 'Requesting a Thumbnail'

### DIFF
--- a/docs/reference/files.md
+++ b/docs/reference/files.md
@@ -80,7 +80,7 @@ exist, it is dynamically generated and immediately returned.
 
 ### Preset Transformations
 
-- **`key`** — This **key** of the [Storage Asset Preset](/user-guide/cloud/project-settings#files-thumbnails), a
+- **`key`** — This **key** of the [Storage Asset Preset](/packages/@directus/types/type-aliases/type-alias.SettingsStorageAssetPreset.html), a
   shortcut for the below parameters
 
 ### Custom Transformations


### PR DESCRIPTION
Just a small documentation fix for a broken link